### PR TITLE
Add description and summary to gempspec

### DIFF
--- a/active_record_deprecated_finders.gemspec
+++ b/active_record_deprecated_finders.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/active_record_deprecated_finders/version', __FI
 Gem::Specification.new do |gem|
   gem.authors       = ["Jon Leighton"]
   gem.email         = ["j@jonathanleighton.com"]
-  gem.description   = %q{TODO: Write a gem description}
-  gem.summary       = %q{TODO: Write a gem summary}
+  gem.description   = %q{This gem will be used to extract and deprecate old-style finder option hashes in Active Record.}
+  gem.summary       = %q{This gem will be used to extract and deprecate old-style finder option hashes in Active Record.}
   gem.homepage      = ""
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
Gem was failing to build due to TODO in description and summary. Pulled content from first sentence of README. Adding that content allowed the gem to build.

```
$ rake build
rake aborted!
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    "FIXME" or "TODO" is not a summary

Tasks: TOP => build
(See full trace by running task with --trace)
```

```
$ gem -v
1.8.22
```
