### PR TITLE
Allow mix of lamda scope and deprecated options on associations

### DIFF
--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -49,4 +49,13 @@ describe 'associations' do
     scope = @klass.new.comments
     scope.limit_value.must_equal 5
   end
+
+  it "allows a declaration with a scope and deprecated options" do
+    ActiveSupport::Deprecation.silence do
+      @klass.has_many :comments, -> { limit 5 }, :order=>'b'
+    end
+    scope = @klass.new.comments
+    scope.limit_value.must_equal 5
+    scope.order_values.must_equal ['b']
+  end
 end


### PR DESCRIPTION
When mixing block scopes with the old hash-keys style on an association, the hash keys are ignored. 

My initial thought was "So what? It's deprecated, and you shouldn't mix the two styles anyway."

However, then I started thinking about all the poor souls :fire::japanese_ogre::fire: who, when converting the old style to the block scope, might miss one of the keys.

They would probably all :cry: and start filing issues with Rails saying version 4 broke their app. We should notify them they are still using the old keys!

For example, I had the following code:

``` ruby
class Poop < ActiveRecord::Base
  has_many :jokes, 
      :conditions=>["name like ?", '%ie'], order: 'name'
end
```

When I used `poop.jokes`, I'd get a query like this: 

``` sql
SELECT "jokes".* FROM "jokes" WHERE "jokes"."poop_id" IN (1) 
AND (name like '%ie') ORDER BY name
```

But then when I went to switch to the new style in a hundred places in my app, I missed some, and accidentally made a few of them them look like this:

``` ruby
class Poop < ActiveRecord::Base
  has_many :jokes, 
      ->{ where("name not like ?", '%ie') }, order: 'name'
end
```

Now when I used `poop.jokes`, I'd get a query like this: 

``` sql
SELECT "jokes".* FROM "jokes" WHERE "jokes"."poop_id" IN (1) 
AND (name like '%ie') 
```

I did not get any more deprecation notices, so I thought I was all good :metal:. 

But what happened to my ordering? I didn't notice it was gone!

Well, someone told me, so I went and fixed it. If this pull request gets merged, then humans won't have to notice the error and tell us to fix it -- it will still support the deprecated style, and Rails will tell us we haven't finished our work yet!

I wasn't sure this was the right approach for the code, so if you think there's a better way to accomplish this goal, please feel free to let me know, and I will try it that way!
