### PR TITLE
Use the correct gemspec so SQLite3 gets pulled in with bundle install

### DIFF
--- a/gemfiles/Gemfile-edge
+++ b/gemfiles/Gemfile-edge
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'activerecord-deprecated_finders', :path => '..'
+gemspec :path => '..'
 
 gem 'rails', github: 'rails/rails', branch: 'master'


### PR DESCRIPTION
This ensures SQLite3 will be pulled in on the Travis builds for testing against edge Rails. (The problem I discovered in #6).

It will still fail, for a different reason:

https://github.com/rails/rails/commit/a1bb6c8b06db83546179175b9b2dde7912c86f9b changes `:uniq` to `:distinct`.

I am not sure whether the correct fix is to change the tests to use `:distinct` instead, or if we need to change `ActiveRecord::Relation::VALUE_METHODS` to include `:uniq` ... Or I suppose we could convert `:uniq` to `:distinct` before passing it along? 

If you let me know the correct fix, I will include it as well.
