### PR TITLE
Raise error when mixing block scope with deprecated options

### DIFF
--- a/lib/active_record/deprecated_finders/association_builder.rb
+++ b/lib/active_record/deprecated_finders/association_builder.rb
@@ -38,10 +38,16 @@ module ActiveRecord::Associations::Builder
     self.valid_options += [:select, :conditions, :include, :readonly]
 
     def initialize_with_deprecated_options(model, name, scope, options)
-      if scope.is_a?(Hash)
-        options            = scope
-        deprecated_options = options.slice(*DEPRECATED_OPTIONS)
+      options            = scope if scope.is_a?(Hash)
+      deprecated_options = options.slice(*DEPRECATED_OPTIONS)
 
+      if scope.respond_to?(:call) && !deprecated_options.empty?
+        raise ArgumentError,
+          "Invalid mix of scope block and deprecated finder options on " \
+          "ActiveRecord association: #{model.name}.#{macro} :#{name}"
+      end
+
+      if scope.is_a?(Hash)
         if deprecated_options.empty?
           scope = nil
         else

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -49,4 +49,10 @@ describe 'associations' do
     scope = @klass.new.comments
     scope.limit_value.must_equal 5
   end
+
+  it "raises an ArgumentError when declaration uses both scope and deprecated options" do
+    assert_raises(ArgumentError) do
+      @klass.has_many :comments, -> { limit 5 }, :order=>'b'
+    end
+  end
 end


### PR DESCRIPTION
See #9 for context. 

Summary Scenario: Use both a block scope and deprecated options in defining an association.

Before: It would silently ignore the deprecated options.

After: It raises an `ArgumentError`.

Is the error message OK, or does it need to change?
