### PR TITLE
better fix for #9994

### DIFF
--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -8,10 +8,26 @@ describe 'associations' do
     Appointment.delete_all
   end
 
+  it 'should respect find_by_anything method defined on the base class' do
+    physician = Physician.create!
+
+    ActiveSupport::Deprecation.silence do
+      assert_equal [], physician.patients.find_by_custom_name
+    end
+  end
+
   it 'find_or_create_by on has_many through should work' do
     physician = Physician.create!
     ActiveSupport::Deprecation.silence do
       physician.patients.find_or_create_by_name('Tim')
+    end
+    assert_equal 1, Appointment.count
+  end
+
+  it 'find_or_create_by with bang on has_many through should work' do
+    physician = Physician.create!
+    ActiveSupport::Deprecation.silence do
+      physician.patients.find_or_create_by_name!('Tim')
     end
     assert_equal 1, Appointment.count
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -50,6 +50,9 @@ class Appointment < ActiveRecord::Base
 end
 
 class Patient < ActiveRecord::Base
+  def self.find_by_custom_name
+    []
+  end
 end
 
 class Physician < ActiveRecord::Base


### PR DESCRIPTION
fixes https://github.com/rails/rails/issues/10304

Fix for #9994 is already applied but it is causing problems.

Previous fix took the approach of applying checking if the
`CollectionProxy` responds to a method or not. If it does
then invoke the method on `CollectionProxy` instance. This was
needed so that the association record could be created for
hm:t .

However this approach is causing problem. If someone defines a
method called `find_by_anything` on base class then this method
is invoked on `CollectionProxy` first. And that's wrong.

In this PR the approach is to send the method to base class and
if the association is of type hm:t and if the method is
`find_or_create` or `find_or_creat!` then invoke.
`save_through_record` on the `proxy_association`.
