### PR TITLE
filling in some gaps in the documentation [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,55 @@
 # Active Record Deprecated Finders
 
-This gem will be used to extract and deprecate old-style finder option
-hashes in Active Record:
+This gem is a dependency of Rails 4.0 to provide deprecated finder
+functionality.
 
-``` ruby
+It will be removed as a dependency in Rails 4.1, but users can manually include
+it in their Gemfile and it will continue to be maintained until Rails 5.
+
+This gem is used to extract and deprecate old-style finder option hashes in
+Active Record:
+
+```ruby
 Post.find(:all, conditions: { published_on: 2.weeks.ago }, limit: 5)
 ```
 
-It will be a dependency of Rails 4.0 to provide the deprecated
-functionality.
+as well as the following dynamic finders:
 
-It will be removed as a dependency in Rails 4.1, but users can manually
-include it in their Gemfile and it will continue to be maintained until
-Rails 5.
+* `find_all_by_...`
+* `find_last_by_...`
+* `scoped_by_...`
+* `find_or_initialize_by_...`
+* `find_or_create_by_...`
+
+Note that `find(primary_key)`, `find_by...`, and `find_by...!` are not
+deprecated.
+
+To avoid reliance on this gem, you'll need to migrate your finder usage.
+
+To migrate dynamic finders to Rails 4.1+:
+
+* `find_all_by_...` should become `where(...)`.
+* `find_last_by_...` should become `where(...).last`.
+* `scoped_by_...` should become `where(...)`.
+* `find_or_initialize_by_...` should become `find_or_initialize_by(...)`.
+* `find_or_create_by_...` should become `find_or_create_by(...)`.
+
+To migrate old-style finder option hashes and for additional information, 
+please refer to:
+
+* [ActiveRecord::FinderMethods][findermethods], 
+  [ActiveRecord::Relation][relation], and 
+  [ActiveRecord::QueryMethods][querymethods] docs.
+* Rails Guide: Upgrading Ruby on Rails ([stable][stableguide] /
+  [edge][edgeguide]).
+
+[findermethods]: 
+http://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html
+[relation]: 
+http://api.rubyonrails.org/classes/ActiveRecord/Relation.html
+[querymethods]: 
+http://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html
+[stableguide]: 
+http://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+[edgeguide]: 
+http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html


### PR DESCRIPTION
Adding more information about the finders that are implemented to the docs and providing some of the migration information provided by @vipulnsward in https://github.com/rails/rails/pull/12015 to the documentation for activerecord-deprecated_finders in the docs that is now provided in the [edge upgrade guide](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html) but still targeted at those transitioning to 4.0.
