### PR TITLE
Only pass `:distinct` if it was specified.

### DIFF
--- a/lib/active_record/deprecated_finders/relation.rb
+++ b/lib/active_record/deprecated_finders/relation.rb
@@ -79,7 +79,7 @@ module ActiveRecord
           )
 
           apply_finder_options(options.except(:distinct), true)
-            .calculate(operation, column_name, :distinct => options[:distinct])
+            .calculate(operation, column_name, options.slice(:distinct))
         else
           super
         end

--- a/test/calculate_test.rb
+++ b/test/calculate_test.rb
@@ -12,4 +12,26 @@ describe 'calculate' do
 
     assert_deprecated { Post.calculate(:sum, :id, conditions: { title: 'foo' }) }.must_equal 5
   end
+
+  it 'should pass :distinct option along' do
+    Post.create id: 1, title: "foo"
+    Post.create id: 2, title: "bar"
+    Post.create id: 3, title: "bar"
+    Post.create id: 4, title: "baz"
+
+    _result, deprecations = collect_deprecations do
+      Post.count(:title, conditions: { title: ["bar", "baz"] }, distinct: true).must_equal 2
+    end
+    assert_equal 2, deprecations.size, deprecations
+  end
+
+  it 'should not issue :distinct deprecation warning when :distinct was not passed' do
+    Post.create id: 1
+    Post.create id: 2, title: "bar"
+
+    _result, deprecations = collect_deprecations do
+      Post.count(conditions: { title: "bar" }).must_equal 1
+    end
+    assert_equal 1, deprecations.size, deprecations
+  end
 end


### PR DESCRIPTION
This prevents `:distinct` deprecation warnings when the option was not passed at all.
The prevented deprecation looks like:

```
DEPRECATION WARNING: The :distinct option for `Relation#count` is deprecated. Please use `Relation#distinct` instead. (eg. `relation.distinct.count`). (called from calculate at /Users/max/Projects/activerecord-deprecated_finders/lib/active_record/deprecated_finders/relation.rb:84)
```

This issue was discovered while working on: https://github.com/rails/rails/issues/13165
