### PR TITLE
require minitest/autorun before minitest/spec to get rid of warnings.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec'
 require 'active_record'
 require 'active_record/deprecated_finders'
 


### PR DESCRIPTION
This removes the following warning:

```
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/minitest-5.1.0/lib/minitest/spec.rb:3:in `require'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/minitest-5.1.0/lib/minitest/spec.rb:3:in `<top (required)>'
  /Users/senny/Projects/activerecord-deprecated_finders/test/helper.rb:2:in `require'
  /Users/senny/Projects/activerecord-deprecated_finders/test/helper.rb:2:in `<top (required)>'
  /Users/senny/Projects/activerecord-deprecated_finders/test/associations_test.rb:1:in `require'
  /Users/senny/Projects/activerecord-deprecated_finders/test/associations_test.rb:1:in `<top (required)>'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:10:in `require'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:9:in `each'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:9:in `block in <main>'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:4:in `select'
  /Users/senny/Projects/activerecord-deprecated_finders/gemfiles/.bundle/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:4:in `<main>'
```
