### PR TITLE
Fix scope chaining

### DIFF
--- a/lib/active_record/deprecated_finders/base.rb
+++ b/lib/active_record/deprecated_finders/base.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         end
 
         if result.is_a?(Hash)
-          @klass.unscoped.apply_finder_options(result, true)
+          @klass.all.apply_finder_options(result, true)
         else
           result
         end

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -14,4 +14,10 @@ describe 'scope' do
     @klass.scope :foo, ->(v) { { conditions: v } }
     assert_deprecated { @klass.foo(:bar) }.where_values.must_equal [:bar]
   end
+
+  it 'supports chaining' do
+    @klass.scope :foo, -> { @klass.where(:foo) }
+    assert_deprecated { @klass.scope :bar, conditions: :bar }
+    @klass.foo.bar.where_values.must_equal [:foo, :bar]
+  end
 end


### PR DESCRIPTION
Currently when chaining a deprecated scope, because of the [unscoped call](https://github.com/rails/activerecord-deprecated_finders/blob/master/lib/active_record/deprecated_finders/base.rb#L46) all previous scopes are destroyed.

This also manifests itself for scopes defined on the top level of STI classes from subclasses.

Ex:

``` ruby
class Post < ActiveRecord::Base
  self.table_name = 'posts'
  scope :foo, -> { where(:foo) }
  scope :bar, conditions: :bar
end

Post.foo.bar.to_sql
=> "SELECT \"posts\".* FROM \"posts\"  WHERE ('bar')"

Post.bar.foo.to_sql
=> "SELECT \"posts\".* FROM \"posts\"  WHERE ('bar') AND ('foo')"
```
